### PR TITLE
Fixed preconnect template string syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ module.exports = function (context) {
             tagName: 'link',
             attributes: {
               rel: 'preconnect',
-              href: '${matomoUrl}',
+              href: `${matomoUrl}`,
             },
           },
           {


### PR DESCRIPTION
## Summary

Change preconnect string syntax to use template string so that matomoUrl can be correctly injected into the preconnect link element


## Related issue

`'${matomoUrl}'` is not a template string. The plugin will inject a literal `"${matomoUrl}"` value into the link tag

## How is this tested?

Tested locally in a docusaurus project using `yarn link` with config:

```js
matomo: {
  matomoUrl: 'https://your.matomo.instance/',
  siteId: 'ID',
},
```

### Before fix 

![image](https://user-images.githubusercontent.com/8733840/135742115-fc2e84f1-96bf-4508-a22f-5f8dc8f3c024.png)

### After fix

![image](https://user-images.githubusercontent.com/8733840/135742155-f482f72d-8a57-477f-8d31-47ae457a8cc9.png)
