### PR TITLE
feat: add tracking option to extend matomo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module.exports = {
       jsLoader: 'matomo.js',
       // optional matomo methods
       tracking: [
-        ["enableHeartBeatTimer"],
+        ['enableHeartBeatTimer'],
         ['setRequestMethod', 'POST']
       ]
     },

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ module.exports = {
       siteId: 'ID',
       phpLoader: 'matomo.php',
       jsLoader: 'matomo.js',
+      // optional matomo methods
+      tracking: [
+        ["enableHeartBeatTimer"]
+      ]
     },
   },
 };

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ module.exports = {
       jsLoader: 'matomo.js',
       // optional matomo methods
       tracking: [
-        ["enableHeartBeatTimer"]
+        ["enableHeartBeatTimer"],
+        ['setRequestMethod', 'POST']
       ]
     },
   },

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ module.exports = function (context) {
   }
   const phpLoader = matomo.phpLoader || 'matomo.php';
   const jsLoader = matomo.jsLoader || 'matomo.js';
+  const tracking = matomo.tracking || [];
 
   const isProd = process.env.NODE_ENV === 'production';
 
@@ -46,13 +47,11 @@ module.exports = function (context) {
             tagName: 'script',
             innerHTML: `
               var _paq = window._paq = window._paq || [];
-              _paq.push(['setRequestMethod', 'POST']);
               _paq.push(['trackPageView']);
               _paq.push(['enableLinkTracking']);
-              _paq.push(['enableHeartBeatTimer']);
+              ${tracking.map(x => `_paq.push(${JSON.stringify(x)})`).join(';')};
               (function() {
                 var u="${matomoUrl}";
-                _paq.push(['setRequestMethod', 'POST']);
                 _paq.push(['setTrackerUrl', u+'${phpLoader}']);
                 _paq.push(['setSiteId', '${siteId}']);
                 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];


### PR DESCRIPTION
Added a way to extend the plugin configuration so that other Matomo options can be used.
Also, removed `'enableHeartBeatTimer` and `setRequestMethod` from the default configs - these can be added if needed.
See README.md changes for usage.