### PR TITLE
chore(deps): also support docusaurus 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.56"
+    "@docusaurus/core": "^2.0.0-alpha.56 || ^3.0.0"
   },
   "engines": {
     "node": ">=12.13.0"


### PR DESCRIPTION
It's a non breaking change as both versions are supported. I also tested it and it works fine.

resolves #6